### PR TITLE
Add local time to countdown title

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -32,7 +32,7 @@ const Hero: FC = (hero?: any) => {
         className={`${hero.darker ? 'opacity-20' : 'opacity-50'} absolute select-none`}
         quality={100}
       />
-      <div className="flex w-full text-white">
+      <div className="flex w-full text-white" title={new Date(hero.net).toString()}>
         <div className="flex-1 flex justify-center items-center flex-col xl:flex-row container m-auto">
           <NextLaunch data={hero} next={hero.next} />
           <Countdown net={hero.net} />


### PR DESCRIPTION
Ideally, in the future, we'll show time's in pad local, user local, and UTC but patching this in just for ease of use at the moment.